### PR TITLE
Bugfix/favorite detail screen

### DIFF
--- a/WhatsForDinner/WhatsForDinner/Views/ContentView.swift
+++ b/WhatsForDinner/WhatsForDinner/Views/ContentView.swift
@@ -46,5 +46,9 @@ struct ContentView_Previews: PreviewProvider {
       .previewDevice(PreviewDevice(rawValue: "iPhone SE (2nd generation)"))
       .previewInterfaceOrientation(.landscapeLeft)
       .preferredColorScheme(.dark)
+    ContentView()
+      .environmentObject(ReviewRecipeViewModel())
+      .environmentObject(FavoriteRecipeViewModel())
+      .previewDevice(PreviewDevice(rawValue: "iPhone SE (2nd generation)"))
   }
 }

--- a/WhatsForDinner/WhatsForDinner/Views/RecipeDetailView.swift
+++ b/WhatsForDinner/WhatsForDinner/Views/RecipeDetailView.swift
@@ -48,8 +48,6 @@ struct TitleView: View {
         .frame(width: 480, height: 360)
         .background(.gray)
         FavoriteButtonView(recipe: recipe)
-          .padding()
-          .offset(x: 180, y: -160)
       }
     }
   }


### PR DESCRIPTION
The PR is for fixing the issue with the favorite button icon appearing cut-off when viewing on smaller devices like the iPhone SE 2nd generation. The fix was to remove the modifier code used to position the favorite button to the top trailing corner of the image, which now places it in the middle. Any changes to the positioning of the favorite button will be fixed in future branches.